### PR TITLE
Removed duplicate "SETMessage" in "Link Name" Option and removed obstruction

### DIFF
--- a/Files/Scripts/Options/Ocarina of Time.psm1
+++ b/Files/Scripts/Options/Ocarina of Time.psm1
@@ -1600,7 +1600,10 @@ function ByteSceneOptions() {
         PrepareMap -Scene "Lost Woods"      -Map 8 -Header 0; RemoveObject -Name "Kaepora Gaebora"; RemoveActor -Name "Kaepora Gaebora"; SaveAndPatchLoadedScene
         PrepareMap -Scene "Desert Colossus" -Map 0 -Header 0; RemoveObject -Name "Kaepora Gaebora"; RemoveActor -Name "Kaepora Gaebora"; SaveAndPatchLoadedScene
         PrepareMap -Scene "Hyrule Castle"   -Map 0 -Header 0; RemoveObject -Name "Kaepora Gaebora"; RemoveActor -Name "Kaepora Gaebora"; SaveAndPatchLoadedScene
-        if (IsIndex $Redux.Gameplay.RemoveOwls -Index 3) { PrepareMap -Scene "Lake Hylia" -Map 0 -Header 0; RemoveObject -Name "Kaepora Gaebora"; RemoveActor -Name "Kaepora Gaebora"; SaveAndPatchLoadedScene }
+        if (IsIndex $Redux.Gameplay.RemoveOwls -Index 3) { 
+	PrepareMap -Scene "Lake Hylia" -Map 0 -Header 0; RemoveObject -Name "Kaepora Gaebora"; RemoveActor -Name "Kaepora Gaebora"; SaveLoadedMap
+        PrepareMap -Scene "Lake Hylia" -Map 0 -Header 0; RemoveObject -Name "Gravestone"; RemoveActor -Name "Gravestone"; SaveAndPatchLoadedScene
+        }
     }
     
 
@@ -1957,7 +1960,7 @@ function ByteTextOptions() {
         SetMessage -ID "00D7" -Text "0F" -Replace $Redux.Text.LinkName.text;
         SetMessage -ID "00D8";      SetMessage -ID "00D9";      SetMessage -ID "00DB";      SetMessage -ID "00E2"; SetMessage -ID "00EA";      SetMessage -ID "0101"; SetMessage -ID "0102";      SetMessage -ID "011F";      SetMessage -ID "012F";      SetMessage -ID "0131"; SetMessage -ID "0132"
         SetMessage -ID "0133";      SetMessage -ID "015F";      SetMessage -ID "0162";      SetMessage -ID "0165"; SetMessage -ID "0166";      SetMessage -ID "0168"; SetMessage -ID "016A";      SetMessage -ID "016B" -All; SetMessage -ID "016C" -All; SetMessage -ID "018D"; SetMessage -ID "0198"
-        SetMessage -ID "01A3";      SetMessage -ID "01AB";      SetMessage -ID "0218";      SetMessage -ID "022A"; SetMessage -ID "031F";      SetMessage -ID "0626"; SetMessage -ID "1001";      SetMessage -ID "1001";      SetMessage -ID "1002";      SetMessage -ID "1005"; SetMessage -ID "100F"
+        SetMessage -ID "01A3";      SetMessage -ID "01AB";      SetMessage -ID "0218";      SetMessage -ID "022A"; SetMessage -ID "031F";      SetMessage -ID "0626"; SetMessage -ID "1001";      SetMessage -ID "1002";      SetMessage -ID "1005"; SetMessage -ID "100F"
         SetMessage -ID "1015" -All; SetMessage -ID "1017" -All; SetMessage -ID "1024";      SetMessage -ID "1026"; SetMessage -ID "102A" -All; SetMessage -ID "102B"; SetMessage -ID "1045";      SetMessage -ID "1047";      SetMessage -ID "1048";      SetMessage -ID "104B"; SetMessage -ID "1058" -All
         SetMessage -ID "105B";      SetMessage -ID "105C";      SetMessage -ID "1066";      SetMessage -ID "106D"; SetMessage -ID "1070";      SetMessage -ID "1075"; SetMessage -ID "107A";      SetMessage -ID "107C";      SetMessage -ID "1093";      SetMessage -ID "1094"; SetMessage -ID "1095" -All
         SetMessage -ID "10A8";      SetMessage -ID "10C0";      SetMessage -ID "2000" -All; SetMessage -ID "2005"; SetMessage -ID "2008";      SetMessage -ID "2009"; SetMessage -ID "2010";      SetMessage -ID "2018";      SetMessage -ID "2064";      SetMessage -ID "2068"; SetMessage -ID "206C"


### PR DESCRIPTION
I removed a _**ID : 1001 SetMessage**_ duplicate in _**Link.Text**_ and had to remove a hardcoded gravestone actor in one of "**Remove Owl**" options.

This object prevented the player to get access to the hole with the three **Deku** salesmen as a child, due to hardcoded relation with the **Lake Hylia** Owl, which stayed unmovable with the actor gone.

It's only for the Child **Link**'s version of the map. Adult's one is fine.